### PR TITLE
Delay VPC resolve to stack update time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      # The version commited to the repo is a string letting people know it's set on release. This causes semantic-release
-      # to fail so we set it to something valid here.
-      - name: Set version to a valid string
-        run: npm pkg set version=1.0.0
-
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
 

--- a/src/cdk-constructs/IxElasticache.ts
+++ b/src/cdk-constructs/IxElasticache.ts
@@ -42,12 +42,7 @@ export class IxElasticache extends Construct {
       // Setup VPC subnets
       if (vpc && !vpcSubnetIds) {
         if (deployConfig.isIxDeploy) {
-          vpcSubnetIds = [1, 2, 3].map((subnetNum) =>
-            StringParameter.valueForStringParameter(
-              scope,
-              `/vpc/subnet/private-${deployConfig.workloadGroup}/${subnetNum}/id`,
-            ),
-          );
+          vpcSubnetIds = IxVpcDetails.getVpcSubnetIds(scope);
         } else {
           vpcSubnetIds = vpc.privateSubnets.map((subnet) => subnet.subnetId);
 

--- a/src/cdk-constructs/IxNextjsSite.ts
+++ b/src/cdk-constructs/IxNextjsSite.ts
@@ -53,20 +53,6 @@ export class IxNextjsSite extends NextjsSite {
         vpc: vpcDetails.vpc,
       };
     }
-    if (!props.cdk?.server || !("vpcSubnets" in props.cdk.server)) {
-      props.cdk = props.cdk ?? {};
-      props.cdk.server = {
-        ...props.cdk.server,
-        vpcSubnets: vpcDetails.vpcSubnets,
-      };
-    }
-    if (!props.cdk?.revalidation || !("vpcSubnets" in props.cdk.revalidation)) {
-      props.cdk = props.cdk ?? {};
-      props.cdk.revalidation = {
-        ...props.cdk.revalidation,
-        vpcSubnets: vpcDetails.vpcSubnets,
-      };
-    }
   }
 
   // This must be static because we need to call it in the constructor before super


### PR DESCRIPTION
- Delay VPC resolve to stack update time rather than the current cdk synth time
- Remove now unneeded CI step to rename package to valid package name