### PR TITLE
Add static site construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if (deployConfig.isIxDeploy) {
 ### CDK Constructs
 
 <details>
-<summary><strong>IxNextjsSite</strong> - Deploys a serverless instance of a Next.js</summary>
+<summary><strong>IxNextjsSite</strong> - Deploys a serverless instance of a Next.js.</summary>
 
 IxNextjsSite extends [SST's NextjsSite](https://v2.sst.dev/constructs/NextjsSite) and takes the exact same props.
 
@@ -71,6 +71,30 @@ const site = new IxNextjsSite(stack, "Site", {
   environment: {
     DATABASE_URL: process.env.DATABASE_URL || "",
     SESSION_SECRET: process.env.SESSION_SECRET || "",
+  },
+  // Included by default:
+  // customDomain: {
+  //   domainName: ixDeployConfig.siteDomains[0],
+  //   alternateNames: ixDeployConfig.siteDomains.slice(1)
+  // },
+});
+```
+
+</details>
+
+<details>
+<summary><strong>IxStaticSite</strong> - Deploys a static site.</summary>
+
+IxStaticSite extends [SST's StaticSite](https://v2.sst.dev/constructs/StaticSite) and takes the exact same props.
+
+It will automatically create certificates and DNS records for any custom domains given (including alternative domain names which SST doesn't currently do). If the props `customDomain` is not set the first site domain provided by the IX deployment pipeline will be used as the primary custom domain and if there is more than one domain the rest will be used as alternative domain names. Explicitly setting `customDomain` to `undefined` will ensure no customDomain is used.
+
+```typescript
+import { IxStaticSite } from "@infoxchange/make-it-so/cdk-constructs";
+
+const site = new IxStaticSite(stack, "Site", {
+  environment: {
+    DOOHICKEY_NAME: process.env.DOOHICKEY_NAME || "",
   },
   // Included by default:
   // customDomain: {

--- a/README.md
+++ b/README.md
@@ -31,14 +31,22 @@ if (deployConfig.isIxDeploy) {
 }
 ```
 
-| Name             | Description                          | Type for IX Deploy | Type for non-IX Deploy |
-| ---------------- | ------------------------------------ | ------------------ | ---------------------- |
-| isIxDeploy       | Is deploying via IX pipeline or not  | true               | false                  |
-| appName          | Name of app being deployed           | string             | undefined              |
-| environment      | Name of env app is being deployed to | string             | undefined              |
-| workloadGroup    | The workload group of the app        | string             | undefined              |
-| primaryAwsRegion | AWS Region used by IX                | string             | undefined              |
-| siteDomains      | Domains to be used by the app        | string[]           | []                     |
+| Name              | Description                          | Type for IX Deploy                 | Type for non-IX Deploy |
+| ----------------- | ------------------------------------ | ---------------------------------- | ---------------------- |
+| isIxDeploy        | Is deploying via IX pipeline or not  | true                               | false                  |
+| appName           | Name of app being deployed           | string                             | string                 |
+| environment       | Name of env app is being deployed to | "dev" \| "test" \| "uat" \| "prod" | string                 |
+| workloadGroup     | The workload group of the app        | "ds" \| "srs"                      | string                 |
+| primaryAwsRegion  | AWS Region used by IX                | "ap-southeast-2"                   | string                 |
+| siteDomains       | Domains to be used by the app        | string[]                           | string[]               |
+| isInternalApp     | Domains to be used by the app        | boolean                            | boolean \| undefined   |
+| deploymentType    | Domains to be used by the app        | "docker" \| "serverless"           | string                 |
+| sourceCommitRef   | Domains to be used by the app        | string                             | string                 |
+| sourceCommitHash  | Domains to be used by the app        | string                             | string                 |
+| deployTriggeredBy | Domains to be used by the app        | string                             | string                 |
+| smtpHost          | Domains to be used by the app        | string                             | string                 |
+| smtpPort          | Domains to be used by the app        | number                             | number \| undefined    |
+| clamAVUrl         | Domains to be used by the app        | string                             | string                 |
 
 ### CDK Construct - IxNextjsSite
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/%40infoxchange%2Fmake-it-so)](https://www.npmjs.com/package/@infoxchange/make-it-so)
 
-A helpful little library that allows you to deploy apps on Infoxchange's (IX) infrastructure without having to specify all the implementation details that are specific to IX's deployment environment. You tell it what you want and it will worry about making it happen. Most of the heavily lifting is done by [SST](https://sst.dev/) which is extending to take care the IX related specifics.
+A helpful little library that allows you to deploy apps on Infoxchange's (IX) infrastructure without having to specify all the implementation details that are specific to IX's deployment environment. You tell it what you want and it will worry about making it happen. Most of the heavily lifting is done by [SST (version 2)](https://v2.sst.dev/what-is-sst) which is extending to take care the IX related specifics.
 
 ## Installation
 
@@ -58,7 +58,7 @@ if (deployConfig.isIxDeploy) {
 <details>
 <summary><strong>IxNextjsSite</strong> - Deploys a serverless instance of a Next.js</summary>
 
-IxNextjsSite extends [SST's NextjsSite](https://docs.sst.dev/constructs/NextjsSite) and takes the exact same props.
+IxNextjsSite extends [SST's NextjsSite](https://v2.sst.dev/constructs/NextjsSite) and takes the exact same props.
 
 It will automatically create certificates and DNS records for any custom domains given (including alternative domain names which SST doesn't currently do). If the props `customDomain` is not set the first site domain provided by the IX deployment pipeline will be used as the primary custom domain and if there is more than one domain the rest will be used as alternative domain names. Explicitly setting `customDomain` to `undefined` will ensure no customDomain is used.
 
@@ -85,7 +85,7 @@ const site = new IxNextjsSite(stack, "Site", {
 <details>
 <summary><strong>IxApi</strong> - Deploys an instance of API Gateway.</summary>
 
-IxApi extends [SST's Api](https://docs.sst.dev/constructs/Api) and takes the exact same props.
+IxApi extends [SST's Api](https://v2.sst.dev/constructs/Api) and takes the exact same props.
 
 It will automatically create certificates and DNS records for a single domain that the API should deploy to. If the props `customDomain` is not set the first site domain provided by the IX deployment pipeline will be used as the domain. Explicitly setting `customDomain` to `undefined` will ensure no customDomain is used. Regardless of if a custom domain is set, the API Gateway will still be accessible via the 'api-id.execute-api.region.amazonaws.com' url.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ if (deployConfig.isIxDeploy) {
 }
 ```
 
+<details>
+<summary><strong>Full list of available deployment properties</strong></summary>
+
 | Name              | Description                          | Type for IX Deploy                 | Type for non-IX Deploy |
 | ----------------- | ------------------------------------ | ---------------------------------- | ---------------------- |
 | isIxDeploy        | Is deploying via IX pipeline or not  | true                               | false                  |
@@ -48,9 +51,14 @@ if (deployConfig.isIxDeploy) {
 | smtpPort          | Domains to be used by the app        | number                             | number \| undefined    |
 | clamAVUrl         | Domains to be used by the app        | string                             | string                 |
 
-### CDK Construct - IxNextjsSite
+</details>
 
-Deploys a serverless instance of a Next.js. IxNextjsSite extends [SST's NextjsSite](https://docs.sst.dev/constructs/NextjsSite) and takes the exact same props.
+### CDK Constructs
+
+<details>
+<summary><strong>IxNextjsSite</strong> - Deploys a serverless instance of a Next.js</summary>
+
+IxNextjsSite extends [SST's NextjsSite](https://docs.sst.dev/constructs/NextjsSite) and takes the exact same props.
 
 It will automatically create certificates and DNS records for any custom domains given (including alternative domain names which SST doesn't currently do). If the props `customDomain` is not set the first site domain provided by the IX deployment pipeline will be used as the primary custom domain and if there is more than one domain the rest will be used as alternative domain names. Explicitly setting `customDomain` to `undefined` will ensure no customDomain is used.
 
@@ -72,9 +80,12 @@ const site = new IxNextjsSite(stack, "Site", {
 });
 ```
 
-### CDK Construct - IxApi
+</details>
 
-Deploys an instance of API Gateway. IxApi extends [SST's Api](https://docs.sst.dev/constructs/Api) and takes the exact same props.
+<details>
+<summary><strong>IxApi</strong> - Deploys an instance of API Gateway.</summary>
+
+IxApi extends [SST's Api](https://docs.sst.dev/constructs/Api) and takes the exact same props.
 
 It will automatically create certificates and DNS records for a single domain that the API should deploy to. If the props `customDomain` is not set the first site domain provided by the IX deployment pipeline will be used as the domain. Explicitly setting `customDomain` to `undefined` will ensure no customDomain is used. Regardless of if a custom domain is set, the API Gateway will still be accessible via the 'api-id.execute-api.region.amazonaws.com' url.
 
@@ -89,9 +100,10 @@ const site = new IxApi(stack, "api", {
 });
 ```
 
-### CDK Construct - IxElasticache
+</details>
 
-Deploys an AWS Elasticache cluster, either the redis or the memcached flavour.
+<details>
+<summary><strong>IxElasticache</strong> - Deploys an AWS Elasticache cluster, either the redis or the memcached flavour.</summary>
 
 It will also automatically attach the cluster to the standard IX VPC created in each workload account (unless you explicitly pass a different VPC to be attached with the vpc prop or set the vpc prop to `undefined` which will stop any VPC being attached).
 
@@ -121,9 +133,10 @@ const redisCluster = new IxElasticache(stack, "elasticache", {
 | connectionString | string          | A string with all the details required to connect to the cluster |
 | cluster          | CfnCacheCluster | An AWS CDK CfnCacheCluster instance                              |
 
-### CDK Construct - IxCertificate
+</details>
 
-Creates a new DNS validated ACM certificate for a domain managed by IX.
+<details>
+<summary><strong>IxCertificate</strong> - Creates a new DNS validated ACM certificate for a domain managed by IX.</summary>
 
 ```typescript
 import { IxCertificate } from "@infoxchange/make-it-so/cdk-constructs";
@@ -143,9 +156,12 @@ const domainCert = new IxCertificate(scope, "ExampleDotComCertificate", {
 | subjectAlternativeNames | string[] | (optional) Any domains for the certs "Subject Alternative Name" |
 | region                  | string   | (optional) The AWS region to create the cert in                 |
 
-### CDK Construct - IxDnsRecord
+</details>
 
-Creates a DNS record for a domain managed by IX. Route53 HostedZones for IX managed domains live in the dns-hosting AWS account so if a workload AWS account requires a DNS record to be created this must be done "cross-account". IxDnsRecord handles that part for you. Just give it the details for the DNS record itself and IxDnsRecord will worry about creating it.
+<details>
+<summary><strong>IxDnsRecord</strong> - Creates a DNS record for a domain managed by IX.</summary>
+
+Route53 HostedZones for IX managed domains live in the dns-hosting AWS account so if a workload AWS account requires a DNS record to be created this must be done "cross-account". IxDnsRecord handles that part for you. Just give it the details for the DNS record itself and IxDnsRecord will worry about creating it.
 
 ```typescript
 import { IxDnsRecord } from "@infoxchange/make-it-so/cdk-constructs";
@@ -169,9 +185,10 @@ new IxDnsRecord(scope, "IxDnsRecord", {
 | hostedZoneId | string                                     | (optional) The ID of the Route53 HostedZone belonging to the dns-hosting account in which to create the DNS record. If not given the correct HostedZone will be inferred from the domain in the "value" prop.                   |
 | aliasZoneId  | string                                     | (only needed if type = "Alias") the Route53 HostedZone that the target of the alias record lives in. Generally this will be the well known ID of a HostedZone for a AWS service itself that is managed by AWS, not an end-user. |
 
-### CDK Construct - IxVpcDetails
+</details>
 
-Fetches the standard VPC and subnets that exist in all IX workload aws accounts.
+<details>
+<summary><strong>IxVpcDetails</strong> - Fetches the standard VPC and subnets that exist in all IX workload aws accounts.</summary>
 
 ```typescript
 import { IxVpcDetails } from "@infoxchange/make-it-so/cdk-constructs";
@@ -186,6 +203,8 @@ const vpcDetails = new IxVpcDetails(scope, "VpcDetails");
 | domainName              | string   | Domain name for cert                                            |
 | subjectAlternativeNames | string[] | (optional) Any domains for the certs "Subject Alternative Name" |
 | region                  | string   | (optional) The AWS region to create the cert in                 |
+
+</details>
 
 ## Full Example
 

--- a/release.config.js
+++ b/release.config.js
@@ -1,4 +1,28 @@
 export default {
   branches: ["main", { name: "internal-testing-*", prerelease: true }],
   preset: "conventionalcommits",
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "conventionalcommits",
+        releaseRules: [
+          { breaking: true, release: "major" },
+          { type: "feat", release: "minor" },
+          { revert: true, release: "patch" },
+          { type: "fix", release: "patch" },
+          { type: "perf", release: "patch" },
+          { type: "ci", release: "patch" },
+          { type: "refactor", release: "patch" },
+          { type: "chore", release: "patch" },
+          { type: "docs", scope: "help-text", release: "patch" },
+          { type: "test", release: false },
+          { scope: "no-release", release: false },
+        ],
+      },
+    ],
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github",
+  ],
 };

--- a/src/cdk-constructs/IxApi.ts
+++ b/src/cdk-constructs/IxApi.ts
@@ -2,7 +2,7 @@ import { Api } from "sst/constructs";
 import { IxCertificate } from "./IxCertificate.js";
 import { IxDnsRecord } from "./IxDnsRecord.js";
 import ixDeployConfig from "../deployConfig.js";
-import { convertToBase62Hash } from "../shared.js";
+import { convertToBase62Hash } from "../lib/utils/hash.js";
 
 type ConstructScope = ConstructorParameters<typeof Api>[0];
 type ConstructId = ConstructorParameters<typeof Api>[1];

--- a/src/cdk-constructs/IxDnsRecord.ts
+++ b/src/cdk-constructs/IxDnsRecord.ts
@@ -1,7 +1,7 @@
 import { Construct } from "constructs";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { CustomResource } from "aws-cdk-lib";
-import { remapKeys } from "../shared.js";
+import { remapKeys } from "../lib/utils/objects.js";
 
 type ConstructScope = ConstructorParameters<typeof Construct>[0];
 type ConstructId = ConstructorParameters<typeof Construct>[1];

--- a/src/cdk-constructs/IxNextjsSite.ts
+++ b/src/cdk-constructs/IxNextjsSite.ts
@@ -1,10 +1,17 @@
 import { NextjsSite } from "sst/constructs";
-import { IxCertificate } from "./IxCertificate.js";
-import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
-import { IxVpcDetails } from "./IxVpcDetails.js";
-import { IxDnsRecord } from "./IxDnsRecord.js";
 import ixDeployConfig from "../deployConfig.js";
-import { convertToBase62Hash } from "../shared.js";
+import {
+  getAliasDomain,
+  getAlternativeDomains,
+  getCustomDomains,
+  getPrimaryCustomDomain,
+  getPrimaryDomain,
+  getPrimaryOrigin,
+  setupCertificate,
+  setupCustomDomain,
+  setupDnsRecords,
+  setupVpcDetails,
+} from "../lib/site/support.js";
 
 type ConstructScope = ConstructorParameters<typeof NextjsSite>[0];
 type ConstructId = ConstructorParameters<typeof NextjsSite>[1];
@@ -20,142 +27,39 @@ export class IxNextjsSite extends NextjsSite {
     props: ConstructProps = {},
   ) {
     if (ixDeployConfig.isIxDeploy) {
-      IxNextjsSite.addVpcDetailsToProps(scope, id, props);
-      IxNextjsSite.setupCustomDomain(scope, id, props);
+      props = setupVpcDetails(scope, id, props);
+      props = setupCustomDomain(scope, id, props);
+      props = setupCertificate(scope, id, props);
     }
 
     super(scope, id, props);
 
     if (ixDeployConfig.isIxDeploy) {
-      this.createDnsRecords(scope);
-    }
-  }
-
-  // This must be static because we need to call it in the constructor before super
-  private static addVpcDetailsToProps(
-    scope: ConstructScope,
-    id: ConstructId,
-    props: ConstructProps,
-  ): void {
-    const vpcDetails = new IxVpcDetails(scope, id + "-IxVpcDetails");
-    if (!props.cdk?.server || !("vpc" in props.cdk.server)) {
-      props.cdk = props.cdk ?? {};
-      props.cdk.server = {
-        ...props.cdk.server,
-        vpc: vpcDetails.vpc,
-      };
-    }
-    if (!props.cdk?.revalidation || !("vpc" in props.cdk.revalidation)) {
-      props.cdk = props.cdk ?? {};
-      props.cdk.revalidation = {
-        ...props.cdk.revalidation,
-        vpc: vpcDetails.vpc,
-      };
-    }
-  }
-
-  // This must be static because we need to call it in the constructor before super
-  private static setupCustomDomain(
-    scope: ConstructScope,
-    id: ConstructId,
-    props: ConstructProps,
-  ): void {
-    // Default to using domains names passed in by the pipeline as the custom domain
-    if (ixDeployConfig.isIxDeploy && !("customDomain" in props)) {
-      props.customDomain = {
-        domainName: ixDeployConfig.siteDomains[0],
-        alternateNames: ixDeployConfig.siteDomains.slice(1),
-      };
-    }
-
-    this.setupCertificate(scope, id, props);
-  }
-
-  // This must be static because we need to call it in the constructor before super
-  private static setupCertificate(
-    scope: ConstructScope,
-    id: ConstructId,
-    props: ConstructProps,
-  ): void {
-    if (!props?.customDomain) return;
-
-    if (typeof props.customDomain === "string") {
-      props.customDomain = { domainName: props.customDomain };
-    }
-    const domainName = props.customDomain.domainName;
-    let subjectAlternativeNames = props.customDomain.alternateNames;
-
-    // If domainAlias is provided, ensure it's in the subjectAlternativeNames
-    if (props.customDomain.domainAlias) {
-      subjectAlternativeNames = subjectAlternativeNames ?? [];
-
-      if (!subjectAlternativeNames.includes(props.customDomain.domainAlias)) {
-        subjectAlternativeNames.push(props.customDomain.domainAlias);
-      }
-    }
-
-    const domainCert = new IxCertificate(scope, id + "-IxCertificate", {
-      domainName,
-      subjectAlternativeNames,
-      region: "us-east-1", // CloudFront will only use certificates in us-east-1
-    });
-    props.customDomain.isExternalDomain = true;
-    props.customDomain.cdk = props.customDomain.cdk ?? {};
-    props.customDomain.cdk.certificate = domainCert.acmCertificate;
-  }
-
-  private createDnsRecords(scope: ConstructScope) {
-    if (!this.cdk?.distribution) return;
-
-    for (const domainName of this.customDomains) {
-      const domainNameLogicalId = convertToBase62Hash(domainName);
-
-      new IxDnsRecord(scope, `DnsRecord-${domainNameLogicalId}`, {
-        type: "ALIAS",
-        name: domainName,
-        value: this.cdk.distribution.distributionDomainName,
-        aliasZoneId: CloudFrontTarget.getHostedZoneId(scope),
-        ttl: 900,
-      });
+      setupDnsRecords(this, scope, id, props);
     }
   }
 
   public get customDomains(): string[] {
-    const domainNames = new Set<string>();
-
-    if (this.primaryCustomDomain) domainNames.add(this.primaryCustomDomain);
-    if (this.aliasDomain) domainNames.add(this.aliasDomain);
-    if (this.alternativeDomains.length)
-      this.alternativeDomains.forEach((domain) => domainNames.add(domain));
-
-    return Array.from(domainNames);
+    return getCustomDomains(this.props);
   }
 
   public get primaryCustomDomain(): string | null {
-    if (typeof this.props.customDomain === "string") {
-      return this.props.customDomain;
-    } else if (typeof this.props.customDomain === "object") {
-      return this.props.customDomain.domainName ?? null;
-    }
-    return null;
+    return getPrimaryCustomDomain(this.props);
   }
 
   public get aliasDomain(): string | null {
-    if (typeof this.props.customDomain === "object") {
-      return this.props.customDomain.domainAlias ?? null;
-    }
-    return null;
+    return getAliasDomain(this.props);
   }
 
   public get alternativeDomains(): string[] {
-    if (typeof this.props.customDomain === "object") {
-      return this.props.customDomain.alternateNames ?? [];
-    }
-    return [];
+    return getAlternativeDomains(this.props);
   }
 
-  public primaryDomain =
-    this.primaryCustomDomain ?? this.cdk?.distribution.distributionDomainName;
+  public get primaryDomain(): string | null {
+    return getPrimaryDomain(this, this.props);
+  }
 
-  public primaryOrigin = `https://${this.primaryDomain}`;
+  public get primaryOrigin(): string | null {
+    return getPrimaryOrigin(this.props);
+  }
 }

--- a/src/cdk-constructs/IxStaticSite.ts
+++ b/src/cdk-constructs/IxStaticSite.ts
@@ -1,0 +1,67 @@
+import { StaticSite } from "sst/constructs";
+import ixDeployConfig from "../deployConfig.js";
+import {
+  getAliasDomain,
+  getAlternativeDomains,
+  getCustomDomains,
+  getPrimaryCustomDomain,
+  getPrimaryDomain,
+  getPrimaryOrigin,
+  setupCertificate,
+  setupCustomDomain,
+  setupDnsRecords,
+} from "../lib/site/support.js";
+
+type ConstructScope = ConstructorParameters<typeof StaticSite>[0];
+type ConstructId = ConstructorParameters<typeof StaticSite>[1];
+type ConstructProps = Exclude<
+  ConstructorParameters<typeof StaticSite>[2],
+  undefined
+>;
+
+export class IxStaticSite extends StaticSite {
+  // StaticSite's props are private, so we need to store them separately
+  private propsExtended: ConstructProps;
+
+  constructor(
+    scope: ConstructScope,
+    id: ConstructId,
+    props: ConstructProps = {},
+  ) {
+    if (ixDeployConfig.isIxDeploy) {
+      props = setupCustomDomain(scope, id, props);
+      props = setupCertificate(scope, id, props);
+    }
+
+    super(scope, id, props);
+    this.propsExtended = props;
+
+    if (ixDeployConfig.isIxDeploy) {
+      setupDnsRecords(this, scope, id, props);
+    }
+  }
+
+  public get customDomains(): string[] {
+    return getCustomDomains(this.propsExtended);
+  }
+
+  public get primaryCustomDomain(): string | null {
+    return getPrimaryCustomDomain(this.propsExtended);
+  }
+
+  public get aliasDomain(): string | null {
+    return getAliasDomain(this.propsExtended);
+  }
+
+  public get alternativeDomains(): string[] {
+    return getAlternativeDomains(this.propsExtended);
+  }
+
+  public get primaryDomain(): string | null {
+    return getPrimaryDomain(this, this.propsExtended);
+  }
+
+  public get primaryOrigin(): string | null {
+    return getPrimaryOrigin(this.propsExtended);
+  }
+}

--- a/src/cdk-constructs/index.ts
+++ b/src/cdk-constructs/index.ts
@@ -2,6 +2,7 @@ export * from "./IxVpcDetails.js";
 export * from "./IxCertificate.js";
 export * from "./IxDnsRecord.js";
 export * from "./IxNextjsSite.js";
+export * from "./IxStaticSite.js";
 export * from "./IxElasticache.js";
 export * from "./IxApi.js";
 export * from "./IxQuicksightWorkspace.js";

--- a/src/lib/site/support.ts
+++ b/src/lib/site/support.ts
@@ -1,0 +1,180 @@
+import { Construct } from "constructs";
+import {
+  NextjsSite,
+  NextjsSiteProps,
+  StaticSite,
+  StaticSiteProps,
+} from "sst/constructs";
+import ixDeployConfig from "../../deployConfig.js";
+import { IxCertificate } from "../../cdk-constructs/IxCertificate.js";
+import { IxVpcDetails } from "../../cdk-constructs/IxVpcDetails.js";
+import { IxDnsRecord } from "../../cdk-constructs/IxDnsRecord.js";
+import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
+import { convertToBase62Hash } from "../utils/hash.js";
+
+export function setupCustomDomain<
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(scope: Construct, id: string, props: Readonly<Props>): Props {
+  let updatedProps = props;
+  // Default to using domains names passed in by the pipeline as the custom domain
+  if (ixDeployConfig.isIxDeploy && !("customDomain" in updatedProps)) {
+    updatedProps = {
+      ...updatedProps,
+      customDomain: {
+        domainName: ixDeployConfig.siteDomains[0],
+        alternateNames: ixDeployConfig.siteDomains.slice(1),
+      },
+    };
+  }
+  return updatedProps;
+}
+
+export function setupCertificate<
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(scope: Construct, id: string, props: Readonly<Props>): Props {
+  const updatedProps: Props = { ...props };
+  if (!updatedProps?.customDomain) return updatedProps;
+
+  if (typeof updatedProps.customDomain === "string") {
+    updatedProps.customDomain = { domainName: updatedProps.customDomain };
+  }
+  const domainName = updatedProps.customDomain.domainName;
+  let subjectAlternativeNames = updatedProps.customDomain.alternateNames;
+
+  // If domainAlias is provided, ensure it's in the subjectAlternativeNames
+  if (updatedProps.customDomain.domainAlias) {
+    subjectAlternativeNames = subjectAlternativeNames ?? [];
+
+    if (
+      !subjectAlternativeNames.includes(updatedProps.customDomain.domainAlias)
+    ) {
+      subjectAlternativeNames.push(updatedProps.customDomain.domainAlias);
+    }
+  }
+
+  const domainCert = new IxCertificate(scope, id + "-IxCertificate", {
+    domainName,
+    subjectAlternativeNames,
+    region: "us-east-1", // CloudFront will only use certificates in us-east-1
+  });
+  updatedProps.customDomain.isExternalDomain = true;
+  updatedProps.customDomain.cdk = updatedProps.customDomain.cdk ?? {};
+  updatedProps.customDomain.cdk.certificate = domainCert.acmCertificate;
+
+  return updatedProps;
+}
+
+export function setupVpcDetails<Props extends NextjsSiteProps>(
+  scope: Construct,
+  id: string,
+  props: Readonly<Props>,
+): Props {
+  const updatedProps: Props = { ...props };
+  const vpcDetails = new IxVpcDetails(scope, id + "-IxVpcDetails");
+  if (!updatedProps.cdk?.server || !("vpc" in updatedProps.cdk.server)) {
+    updatedProps.cdk = updatedProps.cdk ?? {};
+    updatedProps.cdk.server = {
+      ...updatedProps.cdk.server,
+      vpc: vpcDetails.vpc,
+    };
+  }
+  if (
+    !updatedProps.cdk?.revalidation ||
+    !("vpc" in updatedProps.cdk.revalidation)
+  ) {
+    updatedProps.cdk = props.cdk ?? {};
+    updatedProps.cdk.revalidation = {
+      ...updatedProps.cdk.revalidation,
+      vpc: vpcDetails.vpc,
+    };
+  }
+  return updatedProps;
+}
+
+export function setupDnsRecords<
+  Instance extends NextjsSite | StaticSite,
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(
+  instance: Instance,
+  scope: Construct,
+  id: string,
+  props: Readonly<Props>,
+): void {
+  if (!instance.cdk?.distribution) return;
+
+  for (const domainName of getCustomDomains(props)) {
+    const domainNameLogicalId = convertToBase62Hash(domainName);
+
+    new IxDnsRecord(scope, `DnsRecord-${domainNameLogicalId}`, {
+      type: "ALIAS",
+      name: domainName,
+      value: instance.cdk.distribution.distributionDomainName,
+      aliasZoneId: CloudFrontTarget.getHostedZoneId(scope),
+      ttl: 900,
+    });
+  }
+}
+
+export function getCustomDomains<
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(props: Readonly<Props>): string[] {
+  const domainNames = new Set<string>();
+
+  const primaryCustomDomain = getPrimaryCustomDomain(props);
+  const aliasDomain = getAliasDomain(props);
+  const alternativeDomains = getAlternativeDomains(props);
+
+  if (primaryCustomDomain) domainNames.add(primaryCustomDomain);
+  if (aliasDomain) domainNames.add(aliasDomain);
+  if (alternativeDomains.length)
+    alternativeDomains.forEach((domain) => domainNames.add(domain));
+
+  return Array.from(domainNames);
+}
+
+export function getPrimaryDomain<
+  Instance extends NextjsSite | StaticSite,
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(instance: Instance, props: Readonly<Props>): string | null {
+  return (
+    getPrimaryCustomDomain(props) ??
+    instance.cdk?.distribution?.distributionDomainName ??
+    null
+  );
+}
+
+export function getPrimaryOrigin<
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(props: Readonly<Props>): string | null {
+  const primaryDomain = getPrimaryCustomDomain(props);
+  return primaryDomain ? `https://${primaryDomain}` : null;
+}
+
+export function getPrimaryCustomDomain<
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(props: Readonly<Props>): string | null {
+  if (typeof props.customDomain === "string") {
+    return props.customDomain;
+  } else if (typeof props.customDomain === "object") {
+    return props.customDomain.domainName ?? null;
+  }
+  return null;
+}
+
+export function getAliasDomain<Props extends StaticSiteProps | NextjsSiteProps>(
+  props: Readonly<Props>,
+): string | null {
+  if (typeof props.customDomain === "object") {
+    return props.customDomain.domainAlias ?? null;
+  }
+  return null;
+}
+
+export function getAlternativeDomains<
+  Props extends StaticSiteProps | NextjsSiteProps,
+>(props: Readonly<Props>): string[] {
+  if (typeof props.customDomain === "object") {
+    return props.customDomain.alternateNames ?? [];
+  }
+  return [];
+}

--- a/src/lib/utils/hash.ts
+++ b/src/lib/utils/hash.ts
@@ -12,15 +12,3 @@ export function convertToBase62Hash(string: string): string {
   }
   return hash;
 }
-
-export function remapKeys(
-  object: Record<string, unknown>,
-  keyMap: Record<string, string>,
-) {
-  return Object.fromEntries(
-    Object.entries(object).map(([key, value]) => {
-      const newKey = keyMap[key] ?? key;
-      return [newKey, value];
-    }),
-  );
-}

--- a/src/lib/utils/objects.ts
+++ b/src/lib/utils/objects.ts
@@ -1,0 +1,11 @@
+export function remapKeys(
+  object: Record<string, unknown>,
+  keyMap: Record<string, string>,
+) {
+  return Object.fromEntries(
+    Object.entries(object).map(([key, value]) => {
+      const newKey = keyMap[key] ?? key;
+      return [newKey, value];
+    }),
+  );
+}


### PR DESCRIPTION
https://infoxchange.atlassian.net/browse/DIRECTORY-749

Adds new IxStaticSite construct which is a wrapper around SST's StaticSite in the same way that IxNextjsSite is a wrapper around SST's NextjsSite

Also adds some missing doco for new deployConfig props + does a bit of a refactor of IxNextjsSite to reduce duplication for IxStaticSite.