### PR TITLE
feat: use pipeline provided site domain aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Also if `isIxManagedDomain` is true DNS records will be automatically created fo
 
 It will also automatically attach the site to the standard IX VPC created in each workload account (unless you explicitly pass other VPC details or set the VPC-related props (see the SST doco) to `undefined`).
 
+#### Options:
+
+| Prop                                 | Type     | Description                                                                                                                                                                                         |
+| ------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [...NextjsSiteProps]                 |          | Any props accepted by [SST's NextjsSite](https://v2.sst.dev/constructs/NextjsSite)                                                                                                                  |
+| customDomain.isIxManagedDomain       | boolean  | (optional) If true will attempt to create DNS records and certs for it using the IX shared infra. Only required if explicitly setting customDomains and you want DNS records + certs setup for them |
+| customDomain.additionalDomainAliases | string[] | (optional) Works like `customDomain.domainAlias` but `domainAlias` only allows one domain, additionalDomainAliases allows setting additional domains                                                |
+
 ```typescript
 import { IxNextjsSite } from "@infoxchange/make-it-so/cdk-constructs";
 
@@ -97,6 +105,14 @@ If the props `customDomain` is not set then the first site domain provided by th
 If `isIxManagedDomain` is true (which is the case if `customDomain` is set automatically using pipeline provided values) and no custom certificate is given then one will be created for any custom domains given (including alternative domain names which the base SST construct doesn't currently do).
 
 Also if `isIxManagedDomain` is true DNS records will be automatically created for them.
+
+#### Options:
+
+| Prop                                 | Type     | Description                                                                                                                                                                                         |
+| ------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [...NextjsSiteProps]                 |          | Any props accepted by [SST's StaticSite](https://v2.sst.dev/constructs/StaticSite)                                                                                                                  |
+| customDomain.isIxManagedDomain       | boolean  | (optional) If true will attempt to create DNS records and certs for it using the IX shared infra. Only required if explicitly setting customDomains and you want DNS records + certs setup for them |
+| customDomain.additionalDomainAliases | string[] | (optional) Works like `customDomain.domainAlias` but `domainAlias` only allows one domain, additionalDomainAliases allows setting additional domains                                                |
 
 ```typescript
 import { IxStaticSite } from "@infoxchange/make-it-so/cdk-constructs";

--- a/src/cdk-constructs/IxCertificate.ts
+++ b/src/cdk-constructs/IxCertificate.ts
@@ -32,7 +32,7 @@ export class IxCertificate extends Construct {
       );
     const certificateCustomResource = new CustomResource(
       scope,
-      "CertificateCustomResource",
+      "CertificateCustomResource-" + id,
       {
         resourceType: "Custom::CertIssuingLambda",
         serviceToken: certificateCreationLambdaArn,

--- a/src/cdk-constructs/IxNextjsSite.ts
+++ b/src/cdk-constructs/IxNextjsSite.ts
@@ -1,6 +1,7 @@
 import { NextjsSite } from "sst/constructs";
 import ixDeployConfig from "../deployConfig.js";
 import {
+  type ExtendedNextjsSiteProps,
   getAliasDomain,
   getAlternativeDomains,
   getCustomDomains,
@@ -10,15 +11,13 @@ import {
   setupCertificate,
   setupCustomDomain,
   setupDnsRecords,
+  setupDomainAliasRedirect,
   setupVpcDetails,
 } from "../lib/site/support.js";
 
 type ConstructScope = ConstructorParameters<typeof NextjsSite>[0];
 type ConstructId = ConstructorParameters<typeof NextjsSite>[1];
-type ConstructProps = Exclude<
-  ConstructorParameters<typeof NextjsSite>[2],
-  undefined
->;
+type ConstructProps = ExtendedNextjsSiteProps;
 
 export class IxNextjsSite extends NextjsSite {
   constructor(
@@ -30,6 +29,7 @@ export class IxNextjsSite extends NextjsSite {
       props = setupVpcDetails(scope, id, props);
       props = setupCustomDomain(scope, id, props);
       props = setupCertificate(scope, id, props);
+      props = setupDomainAliasRedirect(scope, id, props);
     }
 
     super(scope, id, props);

--- a/src/cdk-constructs/IxStaticSite.ts
+++ b/src/cdk-constructs/IxStaticSite.ts
@@ -1,6 +1,7 @@
 import { StaticSite } from "sst/constructs";
 import ixDeployConfig from "../deployConfig.js";
 import {
+  ExtendedStaticSiteProps,
   getAliasDomain,
   getAlternativeDomains,
   getCustomDomains,
@@ -10,14 +11,12 @@ import {
   setupCertificate,
   setupCustomDomain,
   setupDnsRecords,
+  setupDomainAliasRedirect,
 } from "../lib/site/support.js";
 
 type ConstructScope = ConstructorParameters<typeof StaticSite>[0];
 type ConstructId = ConstructorParameters<typeof StaticSite>[1];
-type ConstructProps = Exclude<
-  ConstructorParameters<typeof StaticSite>[2],
-  undefined
->;
+type ConstructProps = ExtendedStaticSiteProps;
 
 export class IxStaticSite extends StaticSite {
   // StaticSite's props are private, so we need to store them separately
@@ -31,6 +30,7 @@ export class IxStaticSite extends StaticSite {
     if (ixDeployConfig.isIxDeploy) {
       props = setupCustomDomain(scope, id, props);
       props = setupCertificate(scope, id, props);
+      props = setupDomainAliasRedirect(scope, id, props);
     }
 
     super(scope, id, props);

--- a/src/cdk-constructs/IxWebsiteRedirect.ts
+++ b/src/cdk-constructs/IxWebsiteRedirect.ts
@@ -1,0 +1,133 @@
+// Based off https://github.com/sst/v2/blob/37578037ff80638e2f0eaf0dc59a83dae52e4e45/packages/sst/src/constructs/cdk/website-redirect.ts
+// Not quite sure why an s3 bucket is used for generating the redirect rather than a cloudfront edge lambda,
+// maybe it's cheaper? In any case it's what SST uses and those devs have put a lot more thought into
+// this that we have so I'm going to trust them on this one.
+
+import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+import {
+  CloudFrontWebDistribution,
+  OriginProtocolPolicy,
+  PriceClass,
+  ViewerCertificate,
+  ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
+import {
+  BlockPublicAccess,
+  Bucket,
+  RedirectProtocol,
+} from "aws-cdk-lib/aws-s3";
+import { ArnFormat, RemovalPolicy, Stack, Token } from "aws-cdk-lib/core";
+import { Construct } from "constructs";
+import { convertToBase62Hash } from "../lib/utils/hash.js";
+import { IxDnsRecord } from "./IxDnsRecord.js";
+import { IxCertificate } from "./IxCertificate.js";
+
+/**
+ * Properties to configure an HTTPS Redirect
+ */
+export interface WebsiteRedirectProps {
+  /**
+   * The redirect target fully qualified domain name (FQDN). An alias record
+   * will be created that points to your CloudFront distribution. Root domain
+   * or sub-domain can be supplied.
+   */
+  readonly targetDomain: string;
+
+  /**
+   * The domain names that will redirect to `targetDomain`
+   *
+   * @default - the domain name of the hosted zone
+   */
+  readonly recordNames: string[];
+
+  /**
+   * The AWS Certificate Manager (ACM) certificate that will be associated with
+   * the CloudFront distribution that will be created. If provided, the certificate must be
+   * stored in us-east-1 (N. Virginia)
+   *
+   * @default - A new certificate is created in us-east-1 (N. Virginia)
+   */
+  readonly certificate?: ICertificate;
+}
+
+/**
+ * Allows creating a domainA -> domainB redirect using CloudFront and S3.
+ * You can specify multiple domains to be redirected.
+ */
+export class IxWebsiteRedirect extends Construct {
+  constructor(scope: Construct, id: string, props: WebsiteRedirectProps) {
+    super(scope, id);
+
+    const domainNames = props.recordNames;
+
+    let redirectCert = props.certificate;
+
+    if (!redirectCert) {
+      const newCert = new IxCertificate(scope, id + "-IxRedirectCertificate", {
+        domainName: domainNames[0],
+        subjectAlternativeNames: domainNames.slice(1),
+        region: "us-east-1", // CloudFront will only use certificates in us-east-1
+      });
+      redirectCert = newCert.acmCertificate;
+    }
+
+    const certificateRegion = Stack.of(this).splitArn(
+      redirectCert.certificateArn,
+      ArnFormat.SLASH_RESOURCE_NAME,
+    ).region;
+    if (
+      !Token.isUnresolved(certificateRegion) &&
+      certificateRegion !== "us-east-1"
+    ) {
+      throw new Error(
+        `The certificate must be in the us-east-1 region and the certificate you provided is in ${certificateRegion}.`,
+      );
+    }
+
+    const redirectBucket = new Bucket(this, "RedirectBucket", {
+      websiteRedirect: {
+        hostName: props.targetDomain,
+        protocol: RedirectProtocol.HTTPS,
+      },
+      removalPolicy: RemovalPolicy.DESTROY,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+    });
+    const redirectDist = new CloudFrontWebDistribution(
+      this,
+      "RedirectDistribution",
+      {
+        defaultRootObject: "",
+        originConfigs: [
+          {
+            behaviors: [{ isDefaultBehavior: true }],
+            customOriginSource: {
+              domainName: redirectBucket.bucketWebsiteDomainName,
+              originProtocolPolicy: OriginProtocolPolicy.HTTP_ONLY,
+            },
+          },
+        ],
+        viewerCertificate: ViewerCertificate.fromAcmCertificate(redirectCert, {
+          aliases: domainNames,
+        }),
+        comment: `Redirect to ${props.targetDomain} from ${domainNames.join(
+          ", ",
+        )}`,
+        priceClass: PriceClass.PRICE_CLASS_ALL,
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      },
+    );
+
+    for (const domainName of domainNames) {
+      const domainNameLogicalId = convertToBase62Hash(domainName);
+
+      new IxDnsRecord(scope, `DnsRecord-Redirect-${domainNameLogicalId}`, {
+        type: "ALIAS",
+        name: domainName,
+        value: redirectDist.distributionDomainName,
+        aliasZoneId: CloudFrontTarget.getHostedZoneId(scope),
+        ttl: 900,
+      });
+    }
+  }
+}

--- a/src/deployConfig.ts
+++ b/src/deployConfig.ts
@@ -7,6 +7,7 @@ const envVars = {
   workloadGroup: process.env.IX_WORKLOAD_GROUP ?? "",
   primaryAwsRegion: process.env.IX_PRIMARY_AWS_REGION ?? "",
   siteDomains: process.env.IX_SITE_DOMAINS ?? "",
+  siteDomainAliases: process.env.IX_SITE_DOMAIN_ALIASES ?? "",
   isInternalApp: process.env.IX_INTERNAL_APP ?? "",
   deploymentType: process.env.IX_DEPLOYMENT_TYPE ?? "",
   sourceCommitRef: process.env.IX_SOURCE_COMMIT_REF ?? "",
@@ -25,6 +26,9 @@ const ixDeployConfigSchema = z
     workloadGroup: z.enum(["ds", "srs"]),
     primaryAwsRegion: z.literal("ap-southeast-2"),
     siteDomains: z
+      .string()
+      .transform((val) => val.split(",").map((domain) => domain.trim())),
+    siteDomainAliases: z
       .string()
       .transform((val) => val.split(",").map((domain) => domain.trim())),
     isInternalApp: z.coerce.boolean(),
@@ -46,6 +50,9 @@ const nonIxDeployConfigSchema = z
     workloadGroup: z.string(),
     primaryAwsRegion: z.string(),
     siteDomains: z
+      .string()
+      .transform((val) => val.split(",").map((domain) => domain.trim())),
+    siteDomainAliases: z
       .string()
       .transform((val) => val.split(",").map((domain) => domain.trim())),
     isInternalApp: z

--- a/src/lib/site/support.ts
+++ b/src/lib/site/support.ts
@@ -7,13 +7,25 @@ import {
 } from "sst/constructs";
 import ixDeployConfig from "../../deployConfig.js";
 import { IxCertificate } from "../../cdk-constructs/IxCertificate.js";
+import { IxWebsiteRedirect } from "../../cdk-constructs/IxWebsiteRedirect.js";
 import { IxVpcDetails } from "../../cdk-constructs/IxVpcDetails.js";
 import { IxDnsRecord } from "../../cdk-constructs/IxDnsRecord.js";
 import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
 import { convertToBase62Hash } from "../utils/hash.js";
+import { type DistributionDomainProps } from "sst/constructs/Distribution.js";
+
+export type ExtendedCustomDomains = DistributionDomainProps & {
+  isIxManagedDomain?: boolean;
+};
+export type ExtendedNextjsSiteProps = Omit<NextjsSiteProps, "customDomain"> & {
+  customDomain?: string | ExtendedCustomDomains;
+};
+export type ExtendedStaticSiteProps = Omit<StaticSiteProps, "customDomain"> & {
+  customDomain?: string | ExtendedCustomDomains;
+};
 
 export function setupCustomDomain<
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(scope: Construct, id: string, props: Readonly<Props>): Props {
   let updatedProps = props;
   // Default to using domains names passed in by the pipeline as the custom domain
@@ -21,8 +33,11 @@ export function setupCustomDomain<
     updatedProps = {
       ...updatedProps,
       customDomain: {
+        isIxManagedDomain: true,
+        isExternalDomain: true,
         domainName: ixDeployConfig.siteDomains[0],
         alternateNames: ixDeployConfig.siteDomains.slice(1),
+        domainAlias: ixDeployConfig.siteDomainAliases[0],
       },
     };
   }
@@ -30,7 +45,7 @@ export function setupCustomDomain<
 }
 
 export function setupCertificate<
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(scope: Construct, id: string, props: Readonly<Props>): Props {
   const updatedProps: Props = { ...props };
   if (!updatedProps?.customDomain) return updatedProps;
@@ -38,33 +53,51 @@ export function setupCertificate<
   if (typeof updatedProps.customDomain === "string") {
     updatedProps.customDomain = { domainName: updatedProps.customDomain };
   }
-  const domainName = updatedProps.customDomain.domainName;
-  let subjectAlternativeNames = updatedProps.customDomain.alternateNames;
 
-  // If domainAlias is provided, ensure it's in the subjectAlternativeNames
-  if (updatedProps.customDomain.domainAlias) {
-    subjectAlternativeNames = subjectAlternativeNames ?? [];
-
-    if (
-      !subjectAlternativeNames.includes(updatedProps.customDomain.domainAlias)
-    ) {
-      subjectAlternativeNames.push(updatedProps.customDomain.domainAlias);
-    }
+  // No cert creation required if isIxManagedDomain is false or a cert is already provided
+  if (
+    !updatedProps.customDomain.isIxManagedDomain &&
+    updatedProps.customDomain.cdk?.certificate
+  ) {
+    return updatedProps;
   }
 
   const domainCert = new IxCertificate(scope, id + "-IxCertificate", {
-    domainName,
-    subjectAlternativeNames,
+    domainName: updatedProps.customDomain.domainName,
+    subjectAlternativeNames: updatedProps.customDomain.alternateNames,
     region: "us-east-1", // CloudFront will only use certificates in us-east-1
   });
-  updatedProps.customDomain.isExternalDomain = true;
   updatedProps.customDomain.cdk = updatedProps.customDomain.cdk ?? {};
   updatedProps.customDomain.cdk.certificate = domainCert.acmCertificate;
 
   return updatedProps;
 }
 
-export function setupVpcDetails<Props extends NextjsSiteProps>(
+export function setupDomainAliasRedirect<
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
+>(scope: Construct, id: string, props: Readonly<Props>): Props {
+  if (
+    typeof props.customDomain !== "object" ||
+    !props.customDomain.domainAlias ||
+    !props.customDomain.isIxManagedDomain ||
+    !props.customDomain.cdk?.certificate
+  ) {
+    return props;
+  }
+  new IxWebsiteRedirect(scope, id + "-IxWebsiteRedirect", {
+    recordNames: [props.customDomain.domainAlias],
+    targetDomain: props.customDomain.domainName,
+  });
+  return {
+    ...props,
+    customDomain: {
+      ...props.customDomain,
+      domainAlias: undefined, // SST's site constructs will complain if domainAlias is set while isExternalDomain is true
+    },
+  };
+}
+
+export function setupVpcDetails<Props extends ExtendedNextjsSiteProps>(
   scope: Construct,
   id: string,
   props: Readonly<Props>,
@@ -93,14 +126,19 @@ export function setupVpcDetails<Props extends NextjsSiteProps>(
 
 export function setupDnsRecords<
   Instance extends NextjsSite | StaticSite,
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(
   instance: Instance,
   scope: Construct,
   id: string,
   props: Readonly<Props>,
 ): void {
-  if (!instance.cdk?.distribution) return;
+  if (
+    !instance.cdk?.distribution ||
+    typeof props.customDomain !== "object" ||
+    !props.customDomain.isIxManagedDomain
+  )
+    return;
 
   for (const domainName of getCustomDomains(props)) {
     const domainNameLogicalId = convertToBase62Hash(domainName);
@@ -116,16 +154,14 @@ export function setupDnsRecords<
 }
 
 export function getCustomDomains<
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(props: Readonly<Props>): string[] {
   const domainNames = new Set<string>();
 
   const primaryCustomDomain = getPrimaryCustomDomain(props);
-  const aliasDomain = getAliasDomain(props);
   const alternativeDomains = getAlternativeDomains(props);
 
   if (primaryCustomDomain) domainNames.add(primaryCustomDomain);
-  if (aliasDomain) domainNames.add(aliasDomain);
   if (alternativeDomains.length)
     alternativeDomains.forEach((domain) => domainNames.add(domain));
 
@@ -134,7 +170,7 @@ export function getCustomDomains<
 
 export function getPrimaryDomain<
   Instance extends NextjsSite | StaticSite,
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(instance: Instance, props: Readonly<Props>): string | null {
   return (
     getPrimaryCustomDomain(props) ??
@@ -144,14 +180,14 @@ export function getPrimaryDomain<
 }
 
 export function getPrimaryOrigin<
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(props: Readonly<Props>): string | null {
   const primaryDomain = getPrimaryCustomDomain(props);
   return primaryDomain ? `https://${primaryDomain}` : null;
 }
 
 export function getPrimaryCustomDomain<
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(props: Readonly<Props>): string | null {
   if (typeof props.customDomain === "string") {
     return props.customDomain;
@@ -161,9 +197,9 @@ export function getPrimaryCustomDomain<
   return null;
 }
 
-export function getAliasDomain<Props extends StaticSiteProps | NextjsSiteProps>(
-  props: Readonly<Props>,
-): string | null {
+export function getAliasDomain<
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
+>(props: Readonly<Props>): string | null {
   if (typeof props.customDomain === "object") {
     return props.customDomain.domainAlias ?? null;
   }
@@ -171,7 +207,7 @@ export function getAliasDomain<Props extends StaticSiteProps | NextjsSiteProps>(
 }
 
 export function getAlternativeDomains<
-  Props extends StaticSiteProps | NextjsSiteProps,
+  Props extends ExtendedStaticSiteProps | ExtendedNextjsSiteProps,
 >(props: Readonly<Props>): string[] {
   if (typeof props.customDomain === "object") {
     return props.customDomain.alternateNames ?? [];

--- a/src/lib/utils/objects.ts
+++ b/src/lib/utils/objects.ts
@@ -1,9 +1,13 @@
-export function remapKeys(
-  object: Record<string, unknown>,
-  keyMap: Record<string, string>,
-) {
+export function remapKeys<
+  SourceObject extends object,
+  MapObject extends Record<keyof SourceObject, string>,
+>(
+  object: SourceObject,
+  keyMap: Readonly<MapObject>,
+): { [k in keyof SourceObject]: MapObject[k] } {
   return Object.fromEntries(
     Object.entries(object).map(([key, value]) => {
+      // @ts-expect-error the typing for map() reduces keys to general string
       const newKey = keyMap[key] ?? key;
       return [newKey, value];
     }),

--- a/tests/__snapshots__/IxCertificate.test.ts.snap
+++ b/tests/__snapshots__/IxCertificate.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`basic example - calls custom resource lambda with correct props 1`] = `
 {
-  "CertificateCustomResource": {
+  "CertificateCustomResourceIxVpcDetails": {
     "DeletionPolicy": "Delete",
     "Properties": {
       "DomainName": "example.com",
@@ -18,7 +18,7 @@ exports[`basic example - calls custom resource lambda with correct props 1`] = `
 
 exports[`full example - calls custom resource lambda with correct props 1`] = `
 {
-  "CertificateCustomResource": {
+  "CertificateCustomResourceIxVpcDetails": {
     "DeletionPolicy": "Delete",
     "Properties": {
       "CertificateIssuingRegion": "us-west-2",


### PR DESCRIPTION
Add new IxWebsiteRedirect construct and update *Site constructs to use it via the `customDomain.domainAlias` prop.

https://infoxchange.atlassian.net/browse/DIRECTORY-752