### PR TITLE
Set http proxy env vars automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ If `isIxManagedDomain` is true (which is the case if `customDomain` is set autom
 
 Also if `isIxManagedDomain` is true DNS records will be automatically created for them.
 
-It will also automatically attach the site to the standard IX VPC created in each workload account (unless you explicitly pass other VPC details or set the VPC-related props (see the SST doco) to `undefined`).
+It will also automatically attach the site to the standard IX VPC created in each workload account (unless you
+explicitly pass other VPC details or set the VPC-related props (see the SST doco) to `undefined`) and set the env vars
+`HTTP_PROXY`, `http_proxy`, `HTTPS_PROXY` and `https_proxy` to the HTTP Proxy for the VPC.
 
 #### Options:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ It will also automatically attach the site to the standard IX VPC created in eac
 explicitly pass other VPC details or set the VPC-related props (see the SST doco) to `undefined`) and set the env vars
 `HTTP_PROXY`, `http_proxy`, `HTTPS_PROXY` and `https_proxy` to the HTTP Proxy for the VPC.
 
+Unlike SST's NextjsSite, any environment variables set with `stackOrApp.setDefaultFunctionProps()` or
+`stackOrApp.addDefaultFunctionEnv()` will be inherited by the IxNextjsSite lambda functions.
+
 #### Options:
 
 | Prop                                 | Type     | Description                                                                                                                                                                                         |

--- a/src/cdk-constructs/IxNextjsSite.ts
+++ b/src/cdk-constructs/IxNextjsSite.ts
@@ -13,6 +13,7 @@ import {
   setupDnsRecords,
   setupDomainAliasRedirect,
   setupVpcDetails,
+  setupDefaultEnvVars,
 } from "../lib/site/support.js";
 
 type ConstructScope = ConstructorParameters<typeof NextjsSite>[0];
@@ -30,6 +31,7 @@ export class IxNextjsSite extends NextjsSite {
       props = setupCustomDomain(scope, id, props);
       props = setupCertificate(scope, id, props);
       props = setupDomainAliasRedirect(scope, id, props);
+      props = setupDefaultEnvVars(scope, id, props);
     }
 
     super(scope, id, props);

--- a/src/deployConfig.ts
+++ b/src/deployConfig.ts
@@ -16,6 +16,7 @@ const envVars = {
   smtpHost: process.env.SMTP_HOST ?? "",
   smtpPort: process.env.SMTP_PORT ?? "",
   clamAVUrl: process.env.CLAMAV_URL ?? "",
+  vpcHttpProxy: process.env.VPC_HTTP_PROXY ?? "",
 } satisfies Record<string, string | boolean>;
 
 const ixDeployConfigSchema = z
@@ -39,6 +40,7 @@ const ixDeployConfigSchema = z
     smtpHost: z.string().min(1),
     smtpPort: z.coerce.number().int(),
     clamAVUrl: z.string().url(),
+    vpcHttpProxy: z.string().url(),
   } satisfies Record<keyof typeof envVars, unknown>)
   .strip();
 
@@ -69,6 +71,7 @@ const nonIxDeployConfigSchema = z
         isNaN(parseInt(val, 10)) ? undefined : parseInt(val, 10),
       ),
     clamAVUrl: z.string(),
+    vpcHttpProxy: z.string(),
   } satisfies Record<keyof typeof envVars, unknown>)
   .strip();
 

--- a/src/lib/site/support.ts
+++ b/src/lib/site/support.ts
@@ -119,6 +119,13 @@ export function setupVpcDetails<Props extends ExtendedNextjsSiteProps>(
       ...updatedProps.cdk.server,
       vpc: vpcDetails.vpc,
     };
+    updatedProps.environment = {
+      HTTP_PROXY: ixDeployConfig.vpcHttpProxy,
+      http_proxy: ixDeployConfig.vpcHttpProxy,
+      HTTPS_PROXY: ixDeployConfig.vpcHttpProxy,
+      https_proxy: ixDeployConfig.vpcHttpProxy,
+      ...updatedProps.environment,
+    };
   }
   if (
     !updatedProps.cdk?.revalidation ||

--- a/src/lib/site/support.ts
+++ b/src/lib/site/support.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 import {
   NextjsSite,
   NextjsSiteProps,
+  Stack,
   StaticSite,
   StaticSiteProps,
 } from "sst/constructs";
@@ -136,6 +137,24 @@ export function setupVpcDetails<Props extends ExtendedNextjsSiteProps>(
       ...updatedProps.cdk.revalidation,
       vpc: vpcDetails.vpc,
     };
+  }
+  return updatedProps;
+}
+export function setupDefaultEnvVars<Props extends ExtendedNextjsSiteProps>(
+  scope: Construct | Stack,
+  id: string,
+  props: Readonly<Props>,
+): Props {
+  const updatedProps: Props = { ...props };
+  // NextjsSite functions to not use default env var unfortunately so we have to
+  // explicitly set them ourselves https://github.com/sst/sst/issues/2359
+  if ("defaultFunctionProps" in scope) {
+    for (const funcProps of scope.defaultFunctionProps) {
+      updatedProps.environment = {
+        ...funcProps.environment,
+        ...updatedProps.environment,
+      };
+    }
   }
   return updatedProps;
 }


### PR DESCRIPTION
When auto setting the vpc also auto set the various http proxy env vars.

Also update IxNextjsSite to use any env vars set in addDefaultFunctionEnv()