### PR TITLE
Allow proxy direct import

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -35,7 +35,12 @@ await esbuild.build({
   // (e.g. "./src/components/index.ts") to avoid esbuild including the imported code in both bundles. To allow these
   // package name imports to work even when the source hasn't been built (and thus the package exports point to
   // non-existent files) these imports also be reflected in tsconfig.json path aliases.
-  entryPoints: ["src/components/index.ts", "src/index.ts"],
+  entryPoints: [
+    "src/index.ts",
+    "src/components/index.ts",
+    "src/deployConfig.ts",
+    "src/lib/proxy/index.ts",
+  ],
   bundle: true,
   platform: "node",
   target: "node21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "global-agent": "^3.0.0",
-        "jsonwebtoken": "^9.0.2",
         "undici": "^7.16.0",
         "zod": "^3.24.2"
       },
@@ -24,7 +23,6 @@
         "@types/aws-cloudfront-function": "^1.0.6",
         "@types/aws-lambda": "8.10.159",
         "@types/global-agent": "^3.0.0",
-        "@types/jsonwebtoken": "^9.0.10",
         "esbuild": "^0.27.2",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3526,15 +3524,6 @@
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "license": "MIT"
     },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -3543,11 +3532,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.12.12",
@@ -4309,10 +4293,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -5262,13 +5242,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -7404,26 +7377,6 @@
         "node": "*"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
     "node_modules/just-diff": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
@@ -7435,23 +7388,6 @@
       "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
       "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "license": "MIT"
-    },
-    "node_modules/jwa": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -7676,28 +7612,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.kebabcase": {
@@ -7713,10 +7635,6 @@
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
@@ -11932,24 +11850,6 @@
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/aws-cloudfront-function": "^1.0.6",
     "@types/aws-lambda": "8.10.159",
     "@types/global-agent": "^3.0.0",
-    "@types/jsonwebtoken": "^9.0.10",
     "esbuild": "^0.27.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -65,7 +64,6 @@
   },
   "dependencies": {
     "global-agent": "^3.0.0",
-    "jsonwebtoken": "^9.0.2",
     "undici": "^7.16.0",
     "zod": "^3.24.2"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
-    "./components": "./dist/components/index.js"
+    "./components": "./dist/components/index.js",
+    "./proxy": "./dist/lib/proxy/index.js",
+    "./deployConfig": "./dist/deployConfig.js"
   },
   "lint-staged": {
     "**/*": [

--- a/src/deployConfig.ts
+++ b/src/deployConfig.ts
@@ -19,6 +19,7 @@ const getEnvVars = () =>
     clamAVUrl: process.env.CLAMAV_URL ?? "",
     vpcHttpProxy: process.env.VPC_HTTP_PROXY ?? "",
     alarmSnsTopic: process.env.IX_ALARM_SNS_TOPIC ?? "",
+    tags: JSON.parse(process.env.IX_TAGS ?? "{}"),
   }) satisfies Record<string, string | boolean>;
 
 const ixDeployConfigSchema = z
@@ -45,11 +46,12 @@ const ixDeployConfigSchema = z
     sourceCommitRef: z.string().min(1),
     sourceCommitHash: z.string().min(1),
     deployTriggeredBy: z.string().min(1),
-    smtpHost: z.string().min(1),
+    smtpHost: z.string(),
     smtpPort: z.coerce.number().int(),
     clamAVUrl: z.string().url(),
     vpcHttpProxy: z.string().url(),
     alarmSnsTopic: z.string().min(1),
+    tags: z.record(z.string(), z.string()),
   } satisfies Record<keyof ReturnType<typeof getEnvVars>, unknown>)
   .strip();
 
@@ -60,12 +62,18 @@ const nonIxDeployConfigSchema = z
     environment: z.string(),
     workloadGroup: z.string(),
     primaryAwsRegion: z.string(),
-    siteDomains: z
-      .string()
-      .transform((val) => val.split(",").map((domain) => domain.trim())),
-    siteDomainAliases: z
-      .string()
-      .transform((val) => val.split(",").map((domain) => domain.trim())),
+    siteDomains: z.string().transform((val) =>
+      val
+        .split(",")
+        .map((domain) => domain.trim())
+        .filter(Boolean),
+    ),
+    siteDomainAliases: z.string().transform((val) =>
+      val
+        .split(",")
+        .map((domain) => domain.trim())
+        .filter(Boolean),
+    ),
     isInternalApp: z
       .string()
       .transform((val) => (val ? val.toLowerCase() === "true" : undefined)),
@@ -82,6 +90,7 @@ const nonIxDeployConfigSchema = z
     clamAVUrl: z.string(),
     vpcHttpProxy: z.string(),
     alarmSnsTopic: z.string(),
+    tags: z.record(z.string(), z.string()),
   } satisfies Record<keyof ReturnType<typeof getEnvVars>, unknown>)
   .strip();
 

--- a/tests/component-defaults.test.ts
+++ b/tests/component-defaults.test.ts
@@ -8,6 +8,7 @@ import {
   assertDefined,
   assertIsObject,
   unwrapOutput,
+  loadDeployConfigEnvVars,
 } from "./helpers/test-utils.js";
 import { StaticSiteArgs } from "sst3/platform/src/components/aws/static-site.js";
 
@@ -47,6 +48,8 @@ describe("setup", () => {
   });
 
   it("should add default domain to site constructs without domain", async () => {
+    loadDeployConfigEnvVars();
+
     const { setup } = await import("../src/components/setup-components.js");
 
     setup();
@@ -66,7 +69,7 @@ describe("setup", () => {
     assertDefined(args.domain);
     const domain = await unwrapOutput(args.domain);
     assertIsObject(domain);
-    expect(domain.name).toBeDefined();
+    expect(domain.name).toBe("test.example.com");
     expect(domain.dns).toBeDefined();
   });
 

--- a/tests/deployConfig.test.ts
+++ b/tests/deployConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { loadDeployConfigEnvVars } from "./helpers/test-utils";
 
 describe("deployConfig", () => {
   const originalEnv = process.env;
@@ -14,24 +15,10 @@ describe("deployConfig", () => {
 
   describe("IX Deploy Configuration", () => {
     it("should parse valid IX deployment environment variables", async () => {
-      process.env.IX_DEPLOYMENT = "true";
-      process.env.IX_APP_NAME = "test-app";
-      process.env.IX_ENVIRONMENT = "dev";
-      process.env.IX_WORKLOAD_GROUP = "ds";
-      process.env.IX_PRIMARY_AWS_REGION = "ap-southeast-2";
-      process.env.IX_SITE_DOMAINS = "test.example.com,test2.example.com";
-      process.env.IX_SITE_DOMAIN_ALIASES = "alias.example.com";
-      process.env.IX_INTERNAL_APP = "true";
-      process.env.IX_DEPLOYMENT_TYPE = "serverless";
-      process.env.IX_SOURCE_COMMIT_REF = "main";
-      process.env.IX_SOURCE_COMMIT_HASH = "abc123";
-      process.env.IX_DEPLOY_TRIGGERED_BY = "deploy-123";
-      process.env.SMTP_HOST = "smtp.example.com";
-      process.env.SMTP_PORT = "587";
-      process.env.CLAMAV_URL = "http://clamav.example.com";
-      process.env.VPC_HTTP_PROXY = "http://proxy.example.com";
-      process.env.IX_ALARM_SNS_TOPIC =
-        "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic";
+      loadDeployConfigEnvVars({
+        IX_SITE_DOMAINS: "test.example.com,test2.example.com",
+        IX_SITE_DOMAIN_ALIASES: "alias.example.com",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       const config = getDeployConfig();
@@ -55,30 +42,21 @@ describe("deployConfig", () => {
       expect(config.smtpPort).toBe(587);
       expect(config.clamAVUrl).toBe("http://clamav.example.com");
       expect(config.vpcHttpProxy).toBe("http://proxy.example.com");
+      expect(config.tags.project).toBe("test-project");
     });
 
     it("should parse all valid environment values (test, uat, prod)", async () => {
       const environments = ["test", "uat", "prod"] as const;
 
       for (const env of environments) {
-        process.env.IX_DEPLOYMENT = "true";
-        process.env.IX_APP_NAME = "test-app";
-        process.env.IX_ENVIRONMENT = env;
-        process.env.IX_WORKLOAD_GROUP = "srs";
-        process.env.IX_PRIMARY_AWS_REGION = "ap-southeast-2";
-        process.env.IX_SITE_DOMAINS = "test.example.com";
-        process.env.IX_SITE_DOMAIN_ALIASES = "";
-        process.env.IX_INTERNAL_APP = "false";
-        process.env.IX_DEPLOYMENT_TYPE = "docker";
-        process.env.IX_SOURCE_COMMIT_REF = "main";
-        process.env.IX_SOURCE_COMMIT_HASH = "abc123";
-        process.env.IX_DEPLOY_TRIGGERED_BY = "deploy-123";
-        process.env.SMTP_HOST = "smtp.example.com";
-        process.env.SMTP_PORT = "25";
-        process.env.CLAMAV_URL = "http://clamav.example.com";
-        process.env.VPC_HTTP_PROXY = "http://proxy.example.com";
-        process.env.IX_ALARM_SNS_TOPIC =
-          "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic";
+        loadDeployConfigEnvVars({
+          IX_ENVIRONMENT: env,
+          IX_WORKLOAD_GROUP: "srs",
+          IX_SITE_DOMAIN_ALIASES: "",
+          IX_INTERNAL_APP: "false",
+          IX_DEPLOYMENT_TYPE: "docker",
+          SMTP_PORT: "25",
+        });
 
         const { getDeployConfig } = await import("../src/deployConfig.js");
         const config = getDeployConfig();
@@ -89,24 +67,10 @@ describe("deployConfig", () => {
     });
 
     it("should handle comma-separated domains with whitespace", async () => {
-      process.env.IX_DEPLOYMENT = "true";
-      process.env.IX_APP_NAME = "test-app";
-      process.env.IX_ENVIRONMENT = "dev";
-      process.env.IX_WORKLOAD_GROUP = "ds";
-      process.env.IX_PRIMARY_AWS_REGION = "ap-southeast-2";
-      process.env.IX_SITE_DOMAINS = " domain1.com , domain2.com,  domain3.com ";
-      process.env.IX_SITE_DOMAIN_ALIASES = " alias1.com, alias2.com ";
-      process.env.IX_INTERNAL_APP = "true";
-      process.env.IX_DEPLOYMENT_TYPE = "serverless";
-      process.env.IX_SOURCE_COMMIT_REF = "main";
-      process.env.IX_SOURCE_COMMIT_HASH = "abc123";
-      process.env.IX_DEPLOY_TRIGGERED_BY = "deploy-123";
-      process.env.SMTP_HOST = "smtp.example.com";
-      process.env.SMTP_PORT = "587";
-      process.env.CLAMAV_URL = "http://clamav.example.com";
-      process.env.VPC_HTTP_PROXY = "http://proxy.example.com";
-      process.env.IX_ALARM_SNS_TOPIC =
-        "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic";
+      loadDeployConfigEnvVars({
+        IX_SITE_DOMAINS: " domain1.com , domain2.com,  domain3.com ",
+        IX_SITE_DOMAIN_ALIASES: " alias1.com, alias2.com ",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       const config = getDeployConfig();
@@ -120,56 +84,27 @@ describe("deployConfig", () => {
     });
 
     it("should throw error for invalid environment", async () => {
-      process.env.IX_DEPLOYMENT = "true";
-      process.env.IX_APP_NAME = "test-app";
-      process.env.IX_ENVIRONMENT = "invalid-env";
-      process.env.IX_WORKLOAD_GROUP = "ds";
-      process.env.IX_PRIMARY_AWS_REGION = "ap-southeast-2";
-      process.env.IX_SITE_DOMAINS = "test.example.com";
-      process.env.IX_SITE_DOMAIN_ALIASES = "";
-      process.env.IX_INTERNAL_APP = "true";
-      process.env.IX_DEPLOYMENT_TYPE = "serverless";
-      process.env.IX_SOURCE_COMMIT_REF = "main";
-      process.env.IX_SOURCE_COMMIT_HASH = "abc123";
-      process.env.IX_DEPLOY_TRIGGERED_BY = "deploy-123";
-      process.env.SMTP_HOST = "smtp.example.com";
-      process.env.SMTP_PORT = "587";
-      process.env.CLAMAV_URL = "http://clamav.example.com";
-      process.env.VPC_HTTP_PROXY = "http://proxy.example.com";
-      process.env.IX_ALARM_SNS_TOPIC =
-        "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic";
+      loadDeployConfigEnvVars({
+        IX_ENVIRONMENT: "invalid-env",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       expect(() => getDeployConfig()).toThrow();
     });
 
     it("should throw error for invalid workload group", async () => {
-      process.env.IX_DEPLOYMENT = "true";
-      process.env.IX_APP_NAME = "test-app";
-      process.env.IX_ENVIRONMENT = "dev";
-      process.env.IX_WORKLOAD_GROUP = "invalid-group";
-      process.env.IX_PRIMARY_AWS_REGION = "ap-southeast-2";
-      process.env.IX_SITE_DOMAINS = "test.example.com";
-      process.env.IX_SITE_DOMAIN_ALIASES = "";
-      process.env.IX_INTERNAL_APP = "true";
-      process.env.IX_DEPLOYMENT_TYPE = "serverless";
-      process.env.IX_SOURCE_COMMIT_REF = "main";
-      process.env.IX_SOURCE_COMMIT_HASH = "abc123";
-      process.env.IX_DEPLOY_TRIGGERED_BY = "deploy-123";
-      process.env.SMTP_HOST = "smtp.example.com";
-      process.env.SMTP_PORT = "587";
-      process.env.CLAMAV_URL = "http://clamav.example.com";
-      process.env.VPC_HTTP_PROXY = "http://proxy.example.com";
-      process.env.IX_ALARM_SNS_TOPIC =
-        "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic";
+      loadDeployConfigEnvVars({
+        IX_WORKLOAD_GROUP: "invalid-group",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       expect(() => getDeployConfig()).toThrow();
     });
 
     it("should throw error for missing required fields in IX deploy", async () => {
-      process.env.IX_DEPLOYMENT = "true";
-      process.env.IX_APP_NAME = ""; // Missing required field
+      loadDeployConfigEnvVars({
+        IX_APP_NAME: "", // Missing required field
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       expect(() => getDeployConfig()).toThrow();
@@ -178,24 +113,22 @@ describe("deployConfig", () => {
 
   describe("Non-IX Deploy Configuration", () => {
     it("should parse non-IX deployment configuration", async () => {
-      process.env.IX_DEPLOYMENT = "false";
-      process.env.IX_APP_NAME = "test-app";
-      process.env.IX_ENVIRONMENT = "local";
-      process.env.IX_WORKLOAD_GROUP = "custom";
-      process.env.IX_PRIMARY_AWS_REGION = "us-east-1";
-      process.env.IX_SITE_DOMAINS = "localhost:3000";
-      process.env.IX_SITE_DOMAIN_ALIASES = "";
-      process.env.IX_INTERNAL_APP = "true";
-      process.env.IX_DEPLOYMENT_TYPE = "local";
-      process.env.IX_SOURCE_COMMIT_REF = "feature-branch";
-      process.env.IX_SOURCE_COMMIT_HASH = "xyz789";
-      process.env.IX_DEPLOY_TRIGGERED_BY = "manual";
-      process.env.SMTP_HOST = "localhost";
-      process.env.SMTP_PORT = "1025";
-      process.env.CLAMAV_URL = "http://localhost:3310";
-      process.env.VPC_HTTP_PROXY = "http://localhost:8080";
-      process.env.IX_ALARM_SNS_TOPIC =
-        "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic";
+      loadDeployConfigEnvVars({
+        IX_DEPLOYMENT: "false",
+        IX_ENVIRONMENT: "local",
+        IX_WORKLOAD_GROUP: "custom",
+        IX_PRIMARY_AWS_REGION: "us-east-1",
+        IX_SITE_DOMAINS: "localhost:3000",
+        IX_SITE_DOMAIN_ALIASES: "",
+        IX_DEPLOYMENT_TYPE: "local",
+        IX_SOURCE_COMMIT_REF: "feature-branch",
+        IX_SOURCE_COMMIT_HASH: "xyz789",
+        IX_DEPLOY_TRIGGERED_BY: "manual",
+        SMTP_HOST: "localhost",
+        SMTP_PORT: "1025",
+        CLAMAV_URL: "http://localhost:3310",
+        VPC_HTTP_PROXY: "http://localhost:8080",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       const config = getDeployConfig();
@@ -211,7 +144,13 @@ describe("deployConfig", () => {
     });
 
     it("should handle missing optional fields in non-IX deploy", async () => {
-      process.env.IX_DEPLOYMENT = "false";
+      loadDeployConfigEnvVars({
+        IX_DEPLOYMENT: "false",
+        IX_APP_NAME: "",
+        IX_ENVIRONMENT: "",
+        IX_INTERNAL_APP: "",
+        SMTP_PORT: "",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       const config = getDeployConfig();
@@ -224,8 +163,10 @@ describe("deployConfig", () => {
     });
 
     it("should handle invalid port number in non-IX deploy", async () => {
-      process.env.IX_DEPLOYMENT = "false";
-      process.env.SMTP_PORT = "not-a-number";
+      loadDeployConfigEnvVars({
+        IX_DEPLOYMENT: "false",
+        SMTP_PORT: "not-a-number",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       const config = getDeployConfig();
@@ -237,15 +178,21 @@ describe("deployConfig", () => {
 
   describe("getDeployConfig function", () => {
     it("should re-evaluate environment variables on each call", async () => {
-      process.env.IX_DEPLOYMENT = "false";
-      process.env.IX_APP_NAME = "first-app";
+      loadDeployConfigEnvVars({
+        IX_DEPLOYMENT: "false",
+        IX_APP_NAME: "first-app",
+      });
 
       const { getDeployConfig } = await import("../src/deployConfig.js");
       const config1 = getDeployConfig();
       expect(config1.appName).toBe("first-app");
 
       // Change environment variable
-      process.env.IX_APP_NAME = "second-app";
+      loadDeployConfigEnvVars({
+        IX_DEPLOYMENT: "false",
+        IX_APP_NAME: "second-app",
+      });
+
       const config2 = getDeployConfig();
       expect(config2.appName).toBe("second-app");
     });

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -29,3 +29,47 @@ export async function unwrapOutput<T>(
     });
   });
 }
+
+/**
+ * Default environment variables for deploy config tests
+ */
+const DEFAULT_DEPLOY_CONFIG_ENV_VARS = {
+  IX_DEPLOYMENT: "true",
+  IX_APP_NAME: "test-app",
+  IX_ENVIRONMENT: "dev",
+  IX_WORKLOAD_GROUP: "ds",
+  IX_PRIMARY_AWS_REGION: "ap-southeast-2",
+  IX_SITE_DOMAINS: "test.example.com",
+  IX_SITE_DOMAIN_ALIASES: "",
+  IX_INTERNAL_APP: "true",
+  IX_DEPLOYMENT_TYPE: "serverless",
+  IX_SOURCE_COMMIT_REF: "main",
+  IX_SOURCE_COMMIT_HASH: "abc123",
+  IX_DEPLOY_TRIGGERED_BY: "deploy-123",
+  SMTP_HOST: "smtp.example.com",
+  SMTP_PORT: "587",
+  CLAMAV_URL: "http://clamav.example.com",
+  VPC_HTTP_PROXY: "http://proxy.example.com",
+  IX_ALARM_SNS_TOPIC: "arn:aws:sns:ap-southeast-2:123456789012:alarm-topic",
+  IX_TAGS: JSON.stringify({
+    project: "test-project",
+    owner: "test-owner",
+  }),
+};
+
+/**
+ * Load environment variables for deploy config tests with optional overrides
+ * @param overrides - Optional object with key-value pairs to override defaults
+ */
+export function loadDeployConfigEnvVars(
+  overrides?: Record<string, string>,
+): void {
+  const envVars = {
+    ...DEFAULT_DEPLOY_CONFIG_ENV_VARS,
+    ...overrides,
+  };
+
+  Object.entries(envVars).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+}


### PR DESCRIPTION
Allow http proxy helpers to be imported without needing to import the whole package. This is important for docker projects that might want to use this but don't need the pulumi peer dependencies so are not installed.

Also update the deployConfig schema to be inside with the latest config provided by the pipeline