### PR TITLE
chore: simplify publishing a test package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - internal-testing-*
+      - ci-publish-test
 
 permissions:
   id-token: write # Required for OIDC used by NPM
@@ -18,8 +18,6 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: verify
-    # If it's a testing branch deploy it regardless of whether verify passed or not
-    if: ${{ startsWith(github.ref_name, 'internal-testing-') && always() || true }}
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - "*"
       - "!main"
-      - "!internal-testing-*"
+      - "!ci-publish-test"
   pull_request: # We also run on PRs to verify the commit messages of all commits in the PR
     branches:
       - main
-      - internal-testing-*
+      - ci-publish-test
   workflow_call:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -168,4 +168,5 @@ If adding a new component I've found that the easiest way to develop it is by fi
 is intended to be used in. When it appears to be working correctly it can be moved into the make-it-so repos and the app can
 be updated to import that component from make-it-so.
 
-To test change a change in make-it-so create a branch starting with the prefix "internal-testing-". When pushed the CI will release a new package with a pre-release version. It'll look a little something like `2.1.3-internal-testing-name-of-feature.3`. A serverless app using make-it-so can be modified to use this package version and then deployed to a dev environment to test that the make-it-so changes are functioning correctly. Once a change has been merged into main and there are no serverless apps using the pre-release package any more it's a good idea to [delete that version](https://docs.npmjs.com/unpublishing-packages-from-the-registry#unpublishing-a-single-version-of-a-package) to keep the [npm package version history clean](https://www.npmjs.com/package/@infoxchange/make-it-so?activeTab=versions).
+To test change a change in make-it-so run `npx git-publish`. This will build then pushed the built files into a
+new branch. That branch can then be used as a package.json dependency directly.

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -5,9 +5,7 @@ export default {
     (message) =>
       // Allow "wip" commits except when publishing a production release or on PR CI jobs
       process.env.GITHUB_EVENT_NAME !== "pull_request" &&
-      (process.env.GITHUB_WORKFLOW !== "Publish" ||
-        (process.env.GITHUB_REF_NAME?.startsWith("internal-testing-") ??
-          true)) &&
+      process.env.GITHUB_WORKFLOW !== "Publish" &&
       (message === "wip" || message.startsWith("wip:")),
   ],
   extends: ["@commitlint/config-conventional"],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "husky",
     "test": "vitest",
     "//fix-signature-issue-with-pulumiverse-vercel": "The sed command below patches the version of @pulumiverse/vercel in the sst3 platform package to a version that has the fix for the Pulumi signature issue.",
-    "postinstall": "! test -d node_modules/sst3 || ( cd node_modules/sst3/platform && sed -i.bak 's/\"@pulumiverse\\/vercel\": \"1.11.0\"/\"@pulumiverse\\/vercel\": \"3.1.1\"/' package.json && echo 'Installing SST v3 dependencies' && npm install )"
+    "postinstall": "! test -d node_modules/sst3 || ( cd node_modules/sst3/platform && sed -i.bak 's/\"@pulumiverse\\/vercel\": \"1.11.0\"/\"@pulumiverse\\/vercel\": \"3.1.1\"/' package.json && echo 'Installing SST v3 dependencies' && npm install )",
+    "prepack": "npm run build"
   },
   "author": "Infoxchange Vic Dev Team <vicdevs@infoxchange.org>",
   "license": "MIT",

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,3 @@
-import { execSync } from "child_process";
-
-const gitCommit = getGitShortCommit();
-
 export default {
   branches: [
     "main",
@@ -9,9 +5,13 @@ export default {
       name: "sst-v2",
       range: "2.x.x",
     },
+    // There are occasionally times where you need to verify the CI release process. To avoid creating real releases
+    // while still doing a fairly representative test any deployments of this branch will publish a "prerelease" version
     {
-      name: "internal-testing-*",
-      prerelease: `\${name}-${gitCommit}`,
+      name: "ci-publish-test",
+      // Adding a timestamp to the prerelease tags avoids conflicts on rebases where the version
+      // might otherwise be the same as a previously published prerelease version
+      prerelease: `\${name}-${Date.now()}`,
     },
   ],
   preset: "conventionalcommits",
@@ -41,12 +41,3 @@ export default {
     "@semantic-release/github",
   ],
 };
-
-function getGitShortCommit() {
-  try {
-    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
-  } catch (error) {
-    console.error("Failed to get git commit hash:", error);
-    return "unknown";
-  }
-}


### PR DESCRIPTION
Since changes to make-it-so are generally made as part of changes to an app you often need some way to publish make-it-so changes so they can be used for testing with the app. Currently the process is to use the CI to publish pre-release versions to npm. But this is slow and clutters up the npm versions list. I recently came across https://www.npmjs.com/package/git-publish which is a much better fit for this situation.

Occasionally we need to test CI publishing (like if npm changes their auth requirements like they did recently) without actually making a proper release. So we keep that option to do prereleases via the CI but we simplify it to just work with the branch "ci-publish-test" rather than any branch starting with "internal-testing-".