### PR TITLE
Fix setup tags sst conflict

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - sst-v2
-      - internal-testing-*
+      - ci-publish-test
 
 permissions:
   id-token: write # Required for OIDC used by NPM
@@ -18,8 +18,6 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: verify
-    # If it's a testing branch deploy it regardless of whether verify passed or not
-    if: ${{ startsWith(github.ref_name, 'internal-testing-') && always() || true }}
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - "*"
       - "!sst-v2"
-      - "!internal-testing-*"
+      - "!ci-publish-test"
   pull_request: # We also run on PRs to verify the commit messages of all commits in the PR
     branches:
       - sst-v2
-      - internal-testing-*
+      - ci-publish-test
   workflow_call:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -488,4 +488,5 @@ Commit messages must be formatted in the [Conventional Commits](https://www.conv
 
 If adding a new construct the easiest way to develop it maybe by building it in whatever app repo it is intended to be used in. When it appears to be working correctly it can be moved into make-it-so and the app can be updated to import that construct from make-it-so.
 
-To test change a change in make-it-so create a branch starting with the prefix "internal-testing-". When pushed the CI will release a new package with a pre-release version. It'll look a little something like `2.1.3-internal-testing-name-of-feature.3`. A serverless app using make-it-so can be modified to use this package version and then deployed to a dev environment to test that the make-it-so changes are functioning correctly. Once a change has been merged into main and there are no serverless apps using the pre-release package any more it's a good idea to [delete that version](https://docs.npmjs.com/unpublishing-packages-from-the-registry#unpublishing-a-single-version-of-a-package) to keep the [npm package version history clean](https://www.npmjs.com/package/@infoxchange/make-it-so?activeTab=versions).
+To test change a change in make-it-so run `npx git-publish`. This will build then pushed the built files into a
+new branch. That branch can then be used as a package.json dependency directly.

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -5,9 +5,7 @@ export default {
     (message) =>
       // Allow "wip" commits except when publishing a production release or on PR CI jobs
       process.env.GITHUB_EVENT_NAME !== "pull_request" &&
-      (process.env.GITHUB_WORKFLOW !== "Publish" ||
-        (process.env.GITHUB_REF_NAME?.startsWith("internal-testing-") ??
-          true)) &&
+      process.env.GITHUB_WORKFLOW !== "Publish" &&
       (message === "wip" || message.startsWith("wip:")),
   ],
   extends: ["@commitlint/config-conventional"],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint . --fix && prettier . --write && tsc --noEmit",
     "lint:check": "eslint . && prettier . --check && tsc --noEmit",
     "prepare": "husky",
-    "commit": "lint-staged && commit"
+    "commit": "lint-staged && commit",
+    "prepack": "npm run build"
   },
   "author": "Infoxchange Vic Dev Team <vicdevs@infoxchange.org>",
   "license": "MIT",

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,3 @@
-import { execSync } from "child_process";
-
-const gitCommit = getGitShortCommit();
-
 export default {
   branches: [
     "main",
@@ -9,9 +5,13 @@ export default {
       name: "sst-v2",
       range: "2.x.x",
     },
+    // There are occasionally times where you need to verify the CI release process. To avoid creating real releases
+    // while still doing a fairly representative test any deployments of this branch will publish a "prerelease" version
     {
-      name: "internal-testing-*",
-      prerelease: `\${name}-${gitCommit}`,
+      name: "ci-publish-test",
+      // Adding a timestamp to the prerelease tags avoids conflicts on rebases where the version
+      // might otherwise be the same as a previously published prerelease version
+      prerelease: `\${name}-${Date.now()}`,
     },
   ],
   preset: "conventionalcommits",
@@ -41,12 +41,3 @@ export default {
     "@semantic-release/github",
   ],
 };
-
-function getGitShortCommit() {
-  try {
-    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
-  } catch (error) {
-    console.error("Failed to get git commit hash:", error);
-    return "unknown";
-  }
-}

--- a/src/lib/tags/ConditionalTags.ts
+++ b/src/lib/tags/ConditionalTags.ts
@@ -1,4 +1,4 @@
-import { IAspect, Tags } from "aws-cdk-lib";
+import { Aspects, IAspect, Tag } from "aws-cdk-lib";
 import { IConstruct } from "constructs";
 
 export class ConditionalTags implements IAspect {
@@ -10,7 +10,9 @@ export class ConditionalTags implements IAspect {
 
   visit(node: IConstruct) {
     this.getTags(node)?.forEach(({ key, value }) => {
-      Tags.of(node).add(key, value);
+      // We need to use a priority greater than 500 avoid a conflict that occurs with some aspects created by SST.
+      // Since cdk's Tags aspect doesn't let us set a priority we have to use the slightly lower level Tag aspect here.
+      Aspects.of(node).add(new Tag(key, value), { priority: 600 });
     });
   }
 }


### PR DESCRIPTION
Fixes a deployment issue that can result from a conflict with SST.

Also add the same "chore: simplify publishing a test package" commit as is already in the main branch.